### PR TITLE
Code refactoring(model.py,  dataset.py) and add backslash to commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ ViTSTR-Tiny without data augmentation
 ```
 RANDOM=$$
 
-CUDA_VISIBLE_DEVICES=0 python3 train.py --train_data data_lmdb_release/training
---valid_data data_lmdb_release/evaluation --select_data MJ-ST 
---batch_ratio 0.5-0.5 --Transformation None --FeatureExtraction None 
---SequenceModeling None --Prediction None --Transformer 
---TransformerModel=vitstr_tiny_patch16_224 --imgH 224 --imgW 224 
+CUDA_VISIBLE_DEVICES=0 python3 train.py --train_data data_lmdb_release/training \
+--valid_data data_lmdb_release/evaluation --select_data MJ-ST \
+--batch_ratio 0.5-0.5 --Transformation None --FeatureExtraction None \ 
+--SequenceModeling None --Prediction None --Transformer \
+--TransformerModel=vitstr_tiny_patch16_224 --imgH 224 --imgW 224 \
 --manualSeed=$RANDOM  --sensitive
 ```
 
@@ -90,11 +90,11 @@ ViTSTR-Small on a 4-GPU machine
 It is recommended to train larger networks like ViTSTR-Small and ViTSTR-Base on a multi-GPU machine. To keep a fixed batch size at `192`, use the `--batch_size` option. Divide `192` by the number of GPUs. For example, to train ViTSTR-Small on a 4-GPU machine, this would be `--batch_size=48`.
 
 ```
-python3 train.py --train_data data_lmdb_release/training 
---valid_data data_lmdb_release/evaluation --select_data MJ-ST 
---batch_ratio 0.5-0.5 --Transformation None --FeatureExtraction None 
---SequenceModeling None --Prediction None --Transformer 
---TransformerModel=vitstr_small_patch16_224 --imgH 224 --imgW 224 
+python3 train.py --train_data data_lmdb_release/training \
+--valid_data data_lmdb_release/evaluation --select_data MJ-ST \ 
+--batch_ratio 0.5-0.5 --Transformation None --FeatureExtraction None \ 
+--SequenceModeling None --Prediction None --Transformer \
+--TransformerModel=vitstr_small_patch16_224 --imgH 224 --imgW 224 \
 --manualSeed=$RANDOM --sensitive --batch_size=48
 ```
 
@@ -107,12 +107,12 @@ It is recommended to use more workers (eg from default of `4`, use `32` instead)
 Below is a sample configuration for a 4-GPU system using batch size of `192`.
 
 ```
-python3 train.py --train_data data_lmdb_release/training
---valid_data data_lmdb_release/evaluation --select_data MJ-ST 
---batch_ratio 0.5-0.5 --Transformation None --FeatureExtraction None 
---SequenceModeling None --Prediction None --Transformer 
---TransformerModel=vitstr_tiny_patch16_224 --imgH 224 --imgW 224 
---manualSeed=$RANDOM  --sensitive
+python3 train.py --train_data data_lmdb_release/training \
+--valid_data data_lmdb_release/evaluation --select_data MJ-ST \ 
+--batch_ratio 0.5-0.5 --Transformation None --FeatureExtraction None \ 
+--SequenceModeling None --Prediction None --Transformer \
+--TransformerModel=vitstr_tiny_patch16_224 --imgH 224 --imgW 224 \
+--manualSeed=$RANDOM  --sensitive \
 --batch_size=48 --isrand_aug --workers=-1 --scheduler
 ```
 
@@ -122,11 +122,11 @@ python3 train.py --train_data data_lmdb_release/training
 ViTSTR-Tiny. Find the path to `best_accuracy.pth` checkpoint file (usually in `saved_model` folder).
 
 ```
-CUDA_VISIBLE_DEVICES=0 python3 test.py --eval_data data_lmdb_release/evaluation 
---benchmark_all_eval --Transformation None --FeatureExtraction None  
---SequenceModeling None --Prediction None --Transformer 
---TransformerModel=vitstr_tiny_patch16_224 
---sensitive --data_filtering_off  --imgH 224 --imgW 224
+CUDA_VISIBLE_DEVICES=0 python3 test.py --eval_data data_lmdb_release/evaluation \
+--benchmark_all_eval --Transformation None --FeatureExtraction None \
+--SequenceModeling None --Prediction None --Transformer \
+--TransformerModel=vitstr_tiny_patch16_224 \
+--sensitive --data_filtering_off  --imgH 224 --imgW 224 \
 --saved_model <path_to/best_accuracy.pth>
 ```
 

--- a/dataset.py
+++ b/dataset.py
@@ -330,7 +330,7 @@ class DataAugment(object):
         '''
         img = img.resize((self.opt.imgW, self.opt.imgH), Image.BICUBIC)
 
-        if self.opt.eval or isless(self.opt.intact_prob):
+        if self.opt.eval or is_less(self.opt.intact_prob):
             pass
         elif self.opt.isrand_aug or self.isbaseline_aug:
             img = self.rand_aug(img)

--- a/dataset.py
+++ b/dataset.py
@@ -265,7 +265,7 @@ class RawDataset(Dataset):
         return (img, self.image_path_list[index])
 
 
-def isless(prob=0.5):
+def is_less(prob=0.5):
     return np.random.uniform(0,1) < prob
 
 class DataAugment(object):

--- a/model.py
+++ b/model.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import torch
 import torch.nn as nn
 
 from modules.transformation import TPS_SpatialTransformerNetwork
@@ -22,8 +21,6 @@ from modules.feature_extraction import VGG_FeatureExtractor, RCNN_FeatureExtract
 from modules.sequence_modeling import BidirectionalLSTM
 from modules.prediction import Attention
 from modules.vitstr import create_vitstr
-
-import math
 
 
 class Model(nn.Module):
@@ -43,7 +40,7 @@ class Model(nn.Module):
             print('No Transformation module specified')
 
         if opt.Transformer:
-            self.vitstr= create_vitstr(num_tokens=opt.num_class, model=opt.TransformerModel)
+            self.vitstr = create_vitstr(num_tokens=opt.num_class, model=opt.TransformerModel)
             return
 
         """ FeatureExtraction """


### PR DESCRIPTION
model.py
- remove unused library(torch, math)
- add space after `self.vitstr`

dataset.py
- rename function `isless` to `is_less` according to PEP8.
- I think this function should be above the classes for code readability. But I didn't modify it.

README.md 
- add backslash(\\) so that commands can execute right away in shell.