### PR TITLE
Update train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -163,6 +163,7 @@ def train(opt):
 
     while(True):
         # train part
+        opt.eval = False
         image_tensors, labels = train_dataset.get_batch()
         image = image_tensors.to(device)
         if not opt.Transformer:
@@ -200,6 +201,7 @@ def train(opt):
             # for log
             with open(f'./saved_models/{opt.exp_name}/log_train.txt', 'a') as log:
                 model.eval()
+                opt.eval = True
                 with torch.no_grad():
                     valid_loss, current_accuracy, current_norm_ED, preds, confidence_score, labels, infer_time, length_of_data = validation(
                         model, criterion, valid_loader, converter, opt)


### PR DESCRIPTION
The opt eval flag is currently not giving the desired behaviour. The flag gets reset for all dataset the same, resulting after the first evaluation in a disabling of the augmentation pipeline. This should make sure it behaves a expected, a more proper solution would be copy over all the specific attributes for the datasets classes. 